### PR TITLE
feat: add Codex CLI support

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "brooks-lint",
+  "version": "0.6.0",
+  "description": "AI code reviews grounded in six classic engineering books — decay risk diagnostics with book citations, severity labels, and four analysis modes (PR review, architecture audit, tech debt, test quality)",
+  "author": {
+    "name": "hyhmrright",
+    "email": "hyhmrright@gmail.com",
+    "url": "https://github.com/hyhmrright"
+  },
+  "homepage": "https://github.com/hyhmrright/brooks-lint",
+  "repository": "https://github.com/hyhmrright/brooks-lint",
+  "license": "MIT",
+  "keywords": [
+    "code-quality",
+    "code-review",
+    "brooks-law",
+    "mythical-man-month",
+    "architecture",
+    "tech-debt",
+    "test-quality"
+  ],
+  "skills": "./skills/brooks-lint/"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+This repository is an AI-powered code quality tool grounded in six classic engineering books (e.g., *The Mythical Man-Month*, *Code Complete*).
+
+## Core Purpose
+**brooks-lint** is a Codex CLI plugin used to diagnose code quality across six "decay risk" dimensions: Cognitive Overload, Change Propagation, Knowledge Duplication, Accidental Complexity, Dependency Disorder, and Domain Model Distortion.
+
+## Skill Integration
+- **Auto-trigger:** You **must** proactively use the `brooks-lint` skill (located at `skills/brooks-lint/`) whenever discussing code quality, PR reviews, architecture health, test quality, or technical debt.
+- **Skill invocation:** Activate with `$brooks-lint`, then describe the task (e.g., "review this PR", "audit the architecture", "assess tech debt", "review test quality").
+
+## Engineering Standards
+- **Comment Preference:** All internal documentation and configuration should remain in English for international consistency.
+- **The Iron Law:** NEVER suggest fixes before completing risk diagnosis. Every finding MUST follow: **Symptom → Source → Consequence → Remedy**.
+- **Scoring System:** Base score 100. Deductions: 🔴 Critical (−15), 🟡 Warning (−5), 🟢 Suggestion (−1). Floor is 0.
+
+## Project Structure
+- `skills/brooks-lint/`: Core skill definitions and diagnostic guides.
+- `.codex-plugin/`: Plugin metadata for Codex CLI installation.
+- `commands/`: Claude Code slash command definitions (not used by Codex CLI).
+- `evals/`: Performance benchmark test cases.
+
+---
+**Note:** Codex CLI should prioritize instructions found in `AGENTS.md` when operating in this repository.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to brooks-lint are documented here.
 
+## [Unreleased] - Codex CLI Support
+
+### Added
+
+- **Codex CLI support** — brooks-lint now works as a Codex CLI plugin
+  - `.codex-plugin/plugin.json`: Plugin manifest for Codex CLI
+  - `AGENTS.md`: Project instructions file for Codex CLI sessions
+  - README updated with triple-platform installation and usage docs
+
+---
+
 ## [0.6.0] - 2026-03-31
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,8 @@ cp -r skills/brooks-lint/ ~/.claude/skills/brooks-lint
 
 ```
 brooks-lint/
-├── .claude-plugin/          # Plugin metadata for /plugin install
+├── .claude-plugin/          # Claude Code plugin metadata
+├── .codex-plugin/           # Codex CLI plugin metadata
 ├── skills/brooks-lint/      # The skill itself
 │   ├── SKILL.md             # Main skill — self-contained workflow + mode detection
 │   ├── decay-risks.md       # Six decay risk definitions with symptoms + sources
@@ -33,7 +34,8 @@ brooks-lint/
 │   ├── test-decay-risks.md  # Six test-space decay risks (read when running Mode 4)
 │   └── test-guide.md        # Mode 4: Test quality review framework
 ├── hooks/                   # SessionStart hook for session-level awareness
-└── commands/                # /brooks-review, /brooks-audit, /brooks-debt, /brooks-test
+├── commands/                # /brooks-review, /brooks-audit, /brooks-debt, /brooks-test
+└── AGENTS.md                # Codex CLI project instructions
 ```
 
 ### How the skill works

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
   <img src="https://img.shields.io/badge/version-0.6.0-blue.svg" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="MIT License">
   <img src="https://img.shields.io/badge/Claude_Code-Plugin-blueviolet.svg" alt="Claude Code Plugin">
+  <img src="https://img.shields.io/badge/Codex_CLI-Skill-orange.svg" alt="Codex CLI Skill">
   <img src="https://img.shields.io/github/stars/hyhmrright/brooks-lint?style=social" alt="GitHub Stars">
 </p>
 
@@ -182,6 +183,26 @@ cp -r skills/brooks-lint ~/.claude/skills/brooks-lint
 cp -r skills/brooks-lint ~/.gemini/skills/brooks-lint
 ```
 
+### Codex CLI
+
+#### Via Skill Installer (in Codex session)
+```
+Install the brooks-lint skill from hyhmrright/brooks-lint
+```
+
+#### Command Line
+```bash
+python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py \
+  --repo hyhmrright/brooks-lint --path skills/brooks-lint --name brooks-lint
+```
+
+#### Manual Install
+```bash
+git clone https://github.com/hyhmrright/brooks-lint.git /tmp/brooks-lint
+mkdir -p ~/.codex/skills/brooks-lint
+cp -r /tmp/brooks-lint/skills/brooks-lint/* ~/.codex/skills/brooks-lint/
+```
+
 ## Slash Commands
 
 ### Claude Code
@@ -200,6 +221,10 @@ cp -r skills/brooks-lint ~/.gemini/skills/brooks-lint
 | `/brooks-debt` | Tech debt assessment |
 | `/brooks-test` | Test suite health review |
 
+### Codex CLI
+
+Activate the skill with `$brooks-lint`, then describe the task. Mode is auto-detected from context.
+
 The skill also triggers automatically when you discuss code quality, architecture, maintainability, or test health.
 
 ## Usage
@@ -209,6 +234,7 @@ The skill also triggers automatically when you discuss code quality, architectur
 ```
 /brooks-lint:brooks-review          # Claude Code
 /brooks-review                      # Gemini CLI
+$brooks-lint                        # Codex CLI (then say "review this PR")
 ```
 
 Paste a diff or point the AI at changed files. Diagnoses each of the six decay risks with specific findings in Symptom → Source → Consequence → Remedy format.
@@ -218,6 +244,7 @@ Paste a diff or point the AI at changed files. Diagnoses each of the six decay r
 ```
 /brooks-lint:brooks-audit           # Claude Code
 /brooks-audit                       # Gemini CLI
+$brooks-lint                        # Codex CLI (then say "audit the architecture")
 ```
 
 Describe your project structure or share key files. It maps module dependencies, identifies circular dependencies, and checks Conway's Law alignment.
@@ -227,6 +254,7 @@ Describe your project structure or share key files. It maps module dependencies,
 ```
 /brooks-lint:brooks-debt            # Claude Code
 /brooks-debt                        # Gemini CLI
+$brooks-lint                        # Codex CLI (then say "assess tech debt")
 ```
 
 Classifies your debt across the six decay risks, scores each finding by Pain × Spread priority, and produces a prioritized repayment roadmap with Critical / Scheduled / Monitored classification.
@@ -236,6 +264,7 @@ Classifies your debt across the six decay risks, scores each finding by Pain × 
 ```
 /brooks-lint:brooks-test            # Claude Code
 /brooks-test                        # Gemini CLI
+$brooks-lint                        # Codex CLI (then say "review test quality")
 ```
 
 Audits your test suite against six test-space decay risks — Test Obscurity, Test Brittleness, Test Duplication, Mock Abuse, Coverage Illusion, and Architecture Mismatch — sourced from xUnit Test Patterns, The Art of Unit Testing, How Google Tests Software, and Working Effectively with Legacy Code. PR reviews also include a lightweight Step 7 Quick Test Check automatically.
@@ -258,8 +287,9 @@ The decay risks these authors identified are more relevant than ever:
 
 ```
 brooks-lint/
-├── .claude-plugin/              # Plugin metadata for /plugin install
-├── skills/brooks-lint/          # The skill itself
+├── .claude-plugin/              # Claude Code plugin metadata
+├── .codex-plugin/               # Codex CLI plugin metadata
+├── skills/brooks-lint/          # The skill itself (canonical source)
 │   ├── SKILL.md                 # Main skill — Iron Law, mode detection, report template
 │   ├── decay-risks.md           # Six decay risks with symptoms and book citations
 │   ├── pr-review-guide.md       # Mode 1: PR review process (incl. Step 7 Quick Test Check)
@@ -281,7 +311,8 @@ brooks-lint/
 - [x] **v0.3**: Eight Brooks dimensions, documentation completeness scoring
 - [x] **v0.4**: Six-book framework, decay risk dimensions, diagnosis chain, benchmark suite
 - [x] **v0.5**: Test Quality Review (Mode 4) — four testing books, six test decay risks
-- [ ] **v0.6**: GitHub Action for CI/CD integration
+- [x] **v0.6**: Mermaid dependency graph in Architecture Audit
+- [ ] **v0.7**: GitHub Action for CI/CD integration
 - [ ] **v1.0**: VS Code extension
 
 Want to help? The best contributions right now are new eval test cases and improved decay risk symptom patterns. See [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
## Summary

- Add `.codex-plugin/plugin.json` plugin manifest for Codex CLI discovery
- Add `AGENTS.md` project instructions file for Codex CLI sessions
- Update README with three install methods (skill-installer, CLI command, manual) and usage docs for triple-platform support (Claude Code + Gemini CLI + Codex CLI)

Verified end-to-end with Codex CLI v0.118.0 — skill discovery, SKILL.md loading, and full Brooks-Lint report generation all working correctly.

## Test plan

- [x] `codex exec "List all available skills"` discovers `brooks-lint`
- [x] `codex exec "Use brooks-lint to review hooks/session-start"` produces correct report with Health Score, Findings (Symptom → Source → Consequence → Remedy), and Summary
- [x] `install-skill-from-github.py --repo hyhmrright/brooks-lint --path skills/brooks-lint` installs to `~/.codex/skills/brooks-lint/` successfully

🤖 Generated with [Claude Code](https://claude.ai/code)