### PR TITLE
ci(hyhmrright-brooks-lint): refresh HOL workflow action refs

### DIFF
--- a/.github/workflows/codex-plugin-scanner.yml
+++ b/.github/workflows/codex-plugin-scanner.yml
@@ -19,6 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Codex plugin scanner
-        uses: hashgraph-online/hol-codex-plugin-scanner-action@b45d6b583afe05819b24edc8e6418c9ad2e1f1d0 # v1
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@df9c8a41eefff30cc430344c2a32c7a96bf37645 # v1
         with:
           plugin_dir: "."

--- a/.github/workflows/codex-plugin-scanner.yml
+++ b/.github/workflows/codex-plugin-scanner.yml
@@ -19,6 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Codex plugin scanner
-        uses: hashgraph-online/hol-codex-plugin-scanner-action@df9c8a41eefff30cc430344c2a32c7a96bf37645 # v1
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@0f78e6d99032ec198d23a41a8425080a658c07d1 # v1
         with:
           plugin_dir: "."


### PR DESCRIPTION
This refreshes the pinned HOL workflow action refs already present in the repo.

Updated workflow refs:
- `the scanner workflow file`: `HOL ai-plugin-scanner action pin` -> `HOL ai-plugin-scanner action pin`

It only updates the existing workflow action pin(s), does not change runtime code, and does not add secrets or publish behavior.