### PR TITLE
ci: run tests, benchmark, and evals across a Node matrix

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,11 +16,21 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 22, 24]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Set up Node.js
+      - name: Set up Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
-          node-version: 20
+          node-version: ${{ matrix.node-version }}
       - name: Validate repository consistency
         run: node scripts/validate-repo.mjs
+      - name: Unit tests
+        run: npm test
+      - name: Parser benchmark (frozen corpus)
+        run: npm run benchmark
+      - name: Structural eval suite
+        run: npm run evals


### PR DESCRIPTION
## What

`validate.yml` currently runs only `node scripts/validate-repo.mjs`. This PR makes CI also run the three deterministic, network-free checks the repo already ships, and runs the whole job across a Node version matrix.

- `npm test` — the 97-test unit suite (`validate-repo.test.mjs`, covers the parser / SARIF / scoring)
- `npm run benchmark` — the frozen-corpus parser fidelity benchmark (30/30)
- `npm run evals` — the structural eval-suite check (57 scenarios)
- Node matrix `[20, 22, 24]` with `fail-fast: false`

## Why

The README states:

> Because the parser is deterministic and the corpus is frozen, `npm run benchmark` gives everyone the same result, and `npm test` guards it as a regression.

…but CI never actually invoked `npm test` or `npm run benchmark`, so a regression in the parser or SARIF export could land on `main` green. This closes that gap and makes the headline reproducibility claims CI-enforced.

Only `evals:live` needs `ANTHROPIC_API_KEY`; it is intentionally left out so CI stays deterministic and secret-free.

## Verification

All three commands pass locally on Node 20/24 with no network access:

```
npm test        → 97 tests: 97 passed, 0 failed
npm run benchmark → PASS — parser fidelity 100% on the frozen corpus (SARIF 30/30)
npm run evals    → All structural checks passed (57 scenarios)
```