### PR TITLE
feat(parser): broaden the file-location extension allowlist

### DIFF
--- a/scripts/report-parse.mjs
+++ b/scripts/report-parse.mjs
@@ -44,8 +44,12 @@ const EMOJI_SEVERITY = { "🔴": "critical", "🟡": "warning", "🟢": "suggest
 // A path with a directory separator, or a bare filename with a known source
 // extension — optionally followed by `:line`. The extension allowlist keeps
 // prose like "e.g." or "i.e." from being mistaken for a file reference.
+// Within a shared prefix the longer extension must come first (`exs` before
+// `ex`, `cljs` before `clj`) so JS alternation doesn't stop at the short one;
+// the newer extensions lead the list so a bare `c`/`h`/`m` can't shadow `cr`/
+// `hs`/`ml`.
 const LOCATION_RE =
-  /([\w.-]*\/[\w./-]*\.\w+|[\w.-]+\.(?:ts|tsx|js|jsx|mjs|cjs|py|java|go|rb|rs|cc|cpp|cxx|c|h|hpp|cs|php|kt|kts|swift|scala|vue|sql|rsx|m|mm))(?::(\d+))?/;
+  /([\w.-]*\/[\w./-]*\.\w+|[\w.-]+\.(?:astro|cljc|cljs|clj|cr|dart|elm|erl|exs|ex|fsx|fs|gradle|groovy|hs|jl|lua|mli|ml|nim|pl|pm|proto|sol|svelte|tf|zig|ts|tsx|js|jsx|mjs|cjs|py|java|go|rb|rs|cc|cpp|cxx|c|h|hpp|cs|php|kt|kts|swift|scala|vue|sql|rsx|m|mm))(?::(\d+))?/;
 
 function splitTitle(bold) {
   // Dash is the template separator; a colon is a common LLM variant. `.match`

--- a/scripts/validate-repo.test.mjs
+++ b/scripts/validate-repo.test.mjs
@@ -659,6 +659,21 @@ test("does not mistake prose for a file reference", () => {
   assert.deepEqual(extractLocation("see line 3 (i.e. nowhere)"), { file: null, line: null });
 });
 
+// Bare filenames (no `/`) exercise the extension allowlist; a path with a
+// slash would match the first branch's generic `.\w+` regardless of the list.
+test("captures newer-language extensions from bare filenames", () => {
+  assert.deepEqual(extractLocation("bug in user.ex:42"), { file: "user.ex", line: 42 });
+  assert.deepEqual(extractLocation("see main.dart"), { file: "main.dart", line: null });
+  assert.deepEqual(extractLocation("main.tf drifts"), { file: "main.tf", line: null });
+});
+
+test("prefers the longer of two prefix-sharing extensions", () => {
+  // A bare `ex`/`clj`/`ml` must not truncate `.exs`/`.cljs`/`.mli`.
+  assert.equal(extractLocation("runtime.exs boots the app").file, "runtime.exs");
+  assert.equal(extractLocation("core.cljs mounts").file, "core.cljs");
+  assert.equal(extractLocation("parser.mli exports").file, "parser.mli");
+});
+
 // ── sarif: reportToSarif ───────────────────────────────────────────────────
 
 console.log("\nreportToSarif");


### PR DESCRIPTION
## What

`extractLocation` (in `scripts/report-parse.mjs`) recognizes a fixed allowlist of source-file extensions when turning a finding's prose into a SARIF `physicalLocation`. The list covered ~30 extensions and missed a number of mainstream languages, so a finding that cites e.g. `lib/user.ex:42` or `main.dart` got **no** location attached in the SARIF export / CI annotations.

This adds: `astro, clj/cljc/cljs, cr, dart, elm, erl, ex/exs, fs/fsx, gradle, groovy, hs, jl, lua, ml/mli, nim, pl, pm, proto, sol, svelte, tf, zig`.

## Ordering (the subtle part)

JS regex alternation returns the *first* alternative that lets the overall match succeed, not the longest — so ordering is load-bearing here, and both hazards are handled:

1. **Longer-before-shorter within a shared prefix** — `exs` before `ex`, `cljs`/`cljc` before `clj`, `mli` before `ml`, `fsx` before `fs`. Otherwise `runtime.exs` would be captured as `runtime.ex`.
2. **New extensions lead the list** — an existing bare `c`/`h`/`m` sits later, so it can't shadow `cr`/`hs`/`ml`.

None of the added extensions is a prefix of an existing one, so existing extraction is unchanged.

## Verification

```
npm test          → 99 tests: 99 passed, 0 failed   (+2 new tests)
npm run benchmark → 30/30 severity match · risk-code P/R 100% · SARIF 30/30 · PASS
npm run evals     → All structural checks passed (57 scenarios)
```

The frozen-corpus benchmark stays 30/30 — the change only widens which file mentions get a location, it doesn't alter severity counts or risk codes. Added unit coverage for the new extensions and the prefix-precedence rule.