### PR TITLE
fix(validate): stop CLAUDE_PLUGIN_ROOT leaking into the default hook check

### DIFF
--- a/scripts/validate-repo.mjs
+++ b/scripts/validate-repo.mjs
@@ -304,9 +304,14 @@ function checkSecurity() {
 function checkHookOutput() {
   function runHook(env = {}) {
     const tempHome = mkdtempSync(path.join(os.tmpdir(), "brooks-lint-hook-home-"));
+    // The hook branches on CLAUDE_PLUGIN_ROOT, so it must never leak in from the
+    // surrounding shell: a maintainer running `npm run validate` from inside
+    // Claude Code would otherwise get the plugin-shaped output for the default
+    // run and fail a check that has nothing to do with their change.
+    const { CLAUDE_PLUGIN_ROOT: _pluginRoot, ...baseEnv } = process.env;
     const stdout = execFileSync(process.execPath, [path.join(root, "hooks", "session-start.mjs")], {
       cwd: root,
-      env: { ...process.env, HOME: tempHome, ...env },
+      env: { ...baseEnv, HOME: tempHome, ...env },
       encoding: "utf8",
     });
     return JSON.parse(stdout);

--- a/scripts/validate-repo.test.mjs
+++ b/scripts/validate-repo.test.mjs
@@ -827,6 +827,16 @@ test("validate-repo.mjs exits 0 against the current repository", () => {
   // execFileSync throws on non-zero exit — reaching here means exit 0
 });
 
+test("validate-repo.mjs ignores an inherited CLAUDE_PLUGIN_ROOT", () => {
+  // Running `npm run validate` from inside Claude Code exports CLAUDE_PLUGIN_ROOT.
+  // The hook branches on that variable, so leaking it into the default-output
+  // check turned every such run into a spurious failure.
+  execFileSync("node", [path.join(__dirname, "validate-repo.mjs")], {
+    encoding: "utf8",
+    env: { ...process.env, CLAUDE_PLUGIN_ROOT: path.resolve(__dirname, "..") },
+  });
+});
+
 // ── Summary ────────────────────────────────────────────────────────────────
 
 console.log(`\n${passed + failed} tests: ${passed} passed, ${failed} failed`);


### PR DESCRIPTION
## Problem

`npm run validate` and `npm test` fail for anyone who runs them from inside Claude Code:

```
Repository validation failed:
  - hooks/session-start default output must include additional_context
```

`checkHookOutput()` in `scripts/validate-repo.mjs` builds the child environment as
`{ ...process.env, HOME: tempHome, ...env }`, so it inherits everything from the surrounding
shell. `hooks/session-start.mjs` branches on `CLAUDE_PLUGIN_ROOT`:

```js
if (process.env.CLAUDE_PLUGIN_ROOT) {
  return { hookSpecificOutput: { ... } };   // plugin shape
}
return { additional_context: context };     // default shape
```

Claude Code exports `CLAUDE_PLUGIN_ROOT` for every loaded plugin, so the "default" run also
returns the plugin shape and the check fails. The failure has nothing to do with the change
being validated — and it hits the audience most likely to be working on this repo.

Reproduce on a clean checkout of `main`:

```bash
node scripts/validate-repo.mjs                          # passes
CLAUDE_PLUGIN_ROOT=/anything node scripts/validate-repo.mjs   # fails
```

`scripts/validate-repo.test.mjs` re-runs `validate-repo.mjs` as a subprocess with the same
inherited environment, so `npm test` reports `99 tests: 98 passed, 1 failed` under the same
condition.

## Fix

Strip `CLAUDE_PLUGIN_ROOT` from the inherited environment before layering the per-run
overrides. The `runHook({ CLAUDE_PLUGIN_ROOT: "1" })` call still sets it explicitly, so the
plugin-shape assertions are unchanged — the variable is now controlled by the test rather
than by the shell.

Added a regression test that runs `validate-repo.mjs` with `CLAUDE_PLUGIN_ROOT` deliberately
set, which fails on `main` and passes here.

## Verification

```
CLAUDE_PLUGIN_ROOT=/anything node scripts/validate-repo.mjs
  Repository validation passed for version 1.4.2.

CLAUDE_PLUGIN_ROOT=/anything node scripts/validate-repo.test.mjs
  100 tests: 100 passed, 0 failed
```

`npm run benchmark` (30/30 severity match, SARIF 30/30) and `npm run evals` (57 scenarios)
are unaffected and still pass.
