### PR TITLE
fix(release): bump and validate every README badge + docs-site version

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -2,7 +2,8 @@
 name: release
 description: >
   Cut a brooks-lint release: set the version in package.json, propagate it across
-  all four plugin manifests + README badge, write the CHANGELOG entry, validate,
+  all four plugin manifests, every README badge and the docs-site metadata, write
+  the CHANGELOG entry, validate,
   then commit, push, tag, and publish the GitHub release.
   Triggers when the maintainer asks to "release", "cut a release", "ship a new
   version", or "bump and publish" brooks-lint.
@@ -26,7 +27,9 @@ CHANGELOG entry are manual; the script only fans the version out to manifests + 
    its own commit + tag and collide with the manual commit in step 5).
 2. **Propagate.** `npm run bump` — writes the version into
    `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`,
-   `.codex-plugin/plugin.json`, `gemini-extension.json`, and the README badge.
+   `.codex-plugin/plugin.json`, `gemini-extension.json`, the badge in every
+   README (English + all localized siblings), and the JSON-LD `softwareVersion`
+   in `docs/index.html`.
 3. **Write the changelog.** Add a new `## <version>` section at the top of
    `CHANGELOG.md` with categorized notes (Added / Fixed / Changed) summarizing the
    commits since the last release tag (`git log <last-tag>..HEAD --oneline`).

--- a/README.es.md
+++ b/README.es.md
@@ -27,7 +27,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-1.4.0-blue.svg" alt="Version">
+  <img src="https://img.shields.io/badge/version-1.4.2-blue.svg" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="MIT License">
   <img src="https://img.shields.io/badge/Claude_Code-Plugin-blueviolet.svg" alt="Claude Code Plugin">
   <img src="https://img.shields.io/badge/Codex_CLI-Skill-orange.svg" alt="Codex CLI Skill">

--- a/README.ja.md
+++ b/README.ja.md
@@ -27,7 +27,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-1.4.0-blue.svg" alt="Version">
+  <img src="https://img.shields.io/badge/version-1.4.2-blue.svg" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="MIT License">
   <img src="https://img.shields.io/badge/Claude_Code-Plugin-blueviolet.svg" alt="Claude Code Plugin">
   <img src="https://img.shields.io/badge/Codex_CLI-Skill-orange.svg" alt="Codex CLI Skill">

--- a/README.ko.md
+++ b/README.ko.md
@@ -27,7 +27,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-1.4.0-blue.svg" alt="Version">
+  <img src="https://img.shields.io/badge/version-1.4.2-blue.svg" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="MIT License">
   <img src="https://img.shields.io/badge/Claude_Code-Plugin-blueviolet.svg" alt="Claude Code Plugin">
   <img src="https://img.shields.io/badge/Codex_CLI-Skill-orange.svg" alt="Codex CLI Skill">

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -27,7 +27,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-1.4.0-blue.svg" alt="Version">
+  <img src="https://img.shields.io/badge/version-1.4.2-blue.svg" alt="Version">
   <img src="https://img.shields.io/badge/license-MIT-green.svg" alt="MIT License">
   <img src="https://img.shields.io/badge/Claude_Code-Plugin-blueviolet.svg" alt="Claude Code Plugin">
   <img src="https://img.shields.io/badge/Codex_CLI-Skill-orange.svg" alt="Codex CLI Skill">

--- a/docs/index.html
+++ b/docs/index.html
@@ -28,7 +28,7 @@
   "description": "AI code reviews grounded in twelve classic software engineering books. Decay-risk diagnostics with book citations, severity labels, and six analysis modes including full-sweep auto-fix.",
   "url": "https://hyhmrright.github.io/brooks-lint/",
   "image": "https://hyhmrright.github.io/brooks-lint/hero.png",
-  "softwareVersion": "1.4.0",
+  "softwareVersion": "1.4.2",
   "license": "https://github.com/hyhmrright/brooks-lint/blob/main/LICENSE",
   "codeRepository": "https://github.com/hyhmrright/brooks-lint",
   "keywords": "AI code review, code quality, tech debt, architecture audit, test quality, Claude Code plugin, refactoring, clean architecture",

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -4,6 +4,13 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  readmeFiles,
+  versionBadge,
+  VERSION_BADGE_RE,
+  SITE_METADATA_FILE,
+  SOFTWARE_VERSION_RE,
+} from "./versioned-files.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, "..");
@@ -28,11 +35,16 @@ for (const { rel, update } of manifests) {
   console.log(`  ✓ ${rel}`);
 }
 
-for (const readmeRel of ["README.md", "README.zh-CN.md"]) {
+for (const readmeRel of readmeFiles(root)) {
   let readme = readFileSync(path.join(root, readmeRel), "utf8");
-  readme = readme.replace(/version-[\d.]+?-blue\.svg/g, `version-${version}-blue.svg`);
+  readme = readme.replace(VERSION_BADGE_RE, versionBadge(version));
   writeFileSync(path.join(root, readmeRel), readme, "utf8");
   console.log(`  ✓ ${readmeRel} badge`);
 }
+
+let siteMetadata = readFileSync(path.join(root, SITE_METADATA_FILE), "utf8");
+siteMetadata = siteMetadata.replace(SOFTWARE_VERSION_RE, `$1${version}$2`);
+writeFileSync(path.join(root, SITE_METADATA_FILE), siteMetadata, "utf8");
+console.log(`  ✓ ${SITE_METADATA_FILE} softwareVersion`);
 
 console.log(`\nAll manifests updated to ${version}. Run npm run validate to confirm.`);

--- a/scripts/validate-repo.mjs
+++ b/scripts/validate-repo.mjs
@@ -13,6 +13,12 @@ import {
   PRODUCTION_RISK_COUNT,
   TEST_RISK_COUNT,
 } from "./frontmatter.mjs";
+import {
+  readmeFiles,
+  versionBadge,
+  SITE_METADATA_FILE,
+  SOFTWARE_VERSION_RE,
+} from "./versioned-files.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, "..");
@@ -98,9 +104,14 @@ const CANONICAL_INSTALL_CMD = "/plugin marketplace add hyhmrright/brooks-lint";
 
 function checkReadmeIntegrity() {
   const readme = readText("README.md");
-  check(readme.includes(`version-${version}-blue.svg`), `README.md badge does not reference version ${version}`);
-  const readmeZh = readText("README.zh-CN.md");
-  check(readmeZh.includes(`version-${version}-blue.svg`), `README.zh-CN.md badge does not reference version ${version} (run npm run bump)`);
+  // Every localized README carries its own badge — checking only the two that
+  // bump-version.mjs used to rewrite is how ja/ko/es/zh-TW silently fell behind.
+  for (const readmeRel of readmeFiles(root)) {
+    check(
+      readText(readmeRel).includes(versionBadge(version)),
+      `${readmeRel} badge does not reference version ${version} (run npm run bump)`,
+    );
+  }
   check(readme.includes(CANONICAL_INSTALL_CMD), `README.md should contain canonical install command`);
   check(
     readme.includes(`grounded in ${sourceWord} classic engineering books`),
@@ -113,6 +124,13 @@ function checkReadmeIntegrity() {
   check(readme.includes("*The Art of Unit Testing*"), "README.md should list The Art of Unit Testing in the source inventory");
   check(readme.includes("*How Google Tests Software*"), "README.md should list How Google Tests Software in the source inventory");
   check(readme.includes("source-coverage.md"), "README.md should link to the source coverage matrix");
+
+  const siteMetadata = readText(SITE_METADATA_FILE);
+  const softwareVersion = siteMetadata.match(SOFTWARE_VERSION_RE)?.[0];
+  check(
+    softwareVersion?.includes(`"${version}"`),
+    `${SITE_METADATA_FILE} JSON-LD softwareVersion does not reference version ${version} (run npm run bump)`,
+  );
 }
 
 function checkConfigExamples() {

--- a/scripts/validate-repo.test.mjs
+++ b/scripts/validate-repo.test.mjs
@@ -27,6 +27,7 @@ import { parseFindings, countFindings, extractLocation } from "./report-parse.mj
 import { reportToSarif } from "./sarif.mjs";
 import { severityBreached, isRegression } from "./ci-gate.mjs";
 import { summarize } from "./benchmark.mjs";
+import { readmeFiles, versionBadge, SOFTWARE_VERSION_RE } from "./versioned-files.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -816,6 +817,52 @@ test("risk-code extraction has zero false positives / negatives on the corpus", 
   assert.equal(BENCH.fn, 0, `${BENCH.fn} false-negative code(s)`);
   assert.equal(BENCH.precision, 1);
   assert.equal(BENCH.recall, 1);
+});
+
+// ── versioned-files ────────────────────────────────────────────────────────
+
+console.log("\nreadmeFiles");
+
+test("picks up README.md and every localized sibling", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "brooks-lint-readme-"));
+  try {
+    for (const name of ["README.md", "README.zh-CN.md", "README.ja.md", "README.es.md"]) {
+      writeFileSync(path.join(dir, name), "");
+    }
+    assert.deepEqual(readmeFiles(dir), ["README.es.md", "README.ja.md", "README.md", "README.zh-CN.md"]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("ignores docs that merely start with README", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "brooks-lint-readme-"));
+  try {
+    for (const name of ["README.md", "READMEISH.md", "README-CONTRIBUTORS.md", "CHANGELOG.md"]) {
+      writeFileSync(path.join(dir, name), "");
+    }
+    assert.deepEqual(readmeFiles(dir), ["README.md"]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("every README in the repository is listed", () => {
+  const root = path.resolve(__dirname, "..");
+  const found = readmeFiles(root);
+  assert.ok(found.includes("README.md"), "README.md must be listed");
+  assert.ok(found.length >= 2, `expected localized READMEs, got ${found.join(", ")}`);
+});
+
+console.log("\nsoftwareVersion metadata");
+
+test("SOFTWARE_VERSION_RE round-trips a version through the JSON-LD block", () => {
+  const before = '  "softwareVersion": "1.4.0",';
+  assert.equal(before.replace(SOFTWARE_VERSION_RE, "$11.5.0$2"), '  "softwareVersion": "1.5.0",');
+});
+
+test("versionBadge builds the shields.io fragment the READMEs embed", () => {
+  assert.equal(versionBadge("1.4.2"), "version-1.4.2-blue.svg");
 });
 
 // ── Integration: validate-repo.mjs passes against current repo ─────────────

--- a/scripts/versioned-files.mjs
+++ b/scripts/versioned-files.mjs
@@ -1,0 +1,28 @@
+/**
+ * Canonical inventory of the non-manifest files that carry the release version.
+ *
+ * bump-version.mjs writes them and validate-repo.mjs asserts them, both from
+ * this list — so a file can never be bumped without being validated, and a new
+ * translated README is picked up by both sides the moment it lands on disk.
+ */
+
+import { readdirSync } from "node:fs";
+
+// README.md plus every localized sibling (README.zh-CN.md, README.ja.md, …).
+const README_FILE_RE = /^README(\.[A-Za-z]{2}(-[A-Za-z]{2,4})?)?\.md$/;
+
+// The docs site advertises the version through its JSON-LD SoftwareApplication.
+export const SITE_METADATA_FILE = "docs/index.html";
+export const SOFTWARE_VERSION_RE = /("softwareVersion":\s*")[\d.]+(")/;
+
+export const VERSION_BADGE_RE = /version-[\d.]+?-blue\.svg/g;
+
+export function versionBadge(version) {
+  return `version-${version}-blue.svg`;
+}
+
+export function readmeFiles(root) {
+  return readdirSync(root)
+    .filter((entry) => README_FILE_RE.test(entry))
+    .sort();
+}


### PR DESCRIPTION
## Problem

`package.json` is at **1.4.2**, but on `main` today:

| File | Version shown |
|---|---|
| `README.ja.md` line 30 | 1.4.0 |
| `README.ko.md` line 30 | 1.4.0 |
| `README.es.md` line 30 | 1.4.0 |
| `README.zh-TW.md` line 30 | 1.4.0 |
| `docs/index.html` JSON-LD `softwareVersion` | 1.4.0 |

CI is green throughout, because the two halves of the release path agree with each other
instead of with the invariant:

- `scripts/bump-version.mjs` rewrites the badge in `["README.md", "README.zh-CN.md"]`
- `checkReadmeIntegrity()` asserts the badge in `README.md` and `README.zh-CN.md`

The gate is scoped to what the script happens to touch, so the four translated READMEs added
later and the docs-site metadata were never in scope for either. Visitors landing on the
Japanese/Korean/Spanish/Traditional-Chinese README — and search engines reading the
`SoftwareApplication` JSON-LD — see a two-patch-old version.

## Fix

`scripts/versioned-files.mjs` (new, 27 lines) becomes the single inventory of the
non-manifest files that carry the version. `bump-version.mjs` writes from it and
`validate-repo.mjs` asserts from it, so a file cannot be bumped without being gated.

READMEs are discovered from disk (`README.md` + localized siblings) rather than hardcoded —
a seventh translation is picked up by both sides the moment the file lands, which is the same
auto-adapting shape `source-coverage.md` frontmatter already uses for the book list.

Also included:
- the JSON-LD `softwareVersion` in `docs/index.html` is now bumped and gated
- `npm run bump` re-run, bringing the four stale badges and the site metadata to 1.4.2
- `.claude/skills/release/SKILL.md` step 2 updated — it told the maintainer `npm run bump`
  covers "the README badge", singular

## Verification

Reverting only the data (badges back to 1.4.0) makes the gate fail loudly:

```
Repository validation failed:
  - README.es.md badge does not reference version 1.4.2 (run npm run bump)
  - README.ja.md badge does not reference version 1.4.2 (run npm run bump)
  - README.ko.md badge does not reference version 1.4.2 (run npm run bump)
  - README.zh-TW.md badge does not reference version 1.4.2 (run npm run bump)
  - docs/index.html JSON-LD softwareVersion does not reference version 1.4.2 (run npm run bump)
```

After `npm run bump`:

```
node scripts/validate-repo.mjs    Repository validation passed for version 1.4.2.
npm test                          104 tests: 104 passed, 0 failed   (5 new)
npm run benchmark                 PASS — parser fidelity 100% on the frozen corpus.
npm run evals                     All structural checks passed (57 scenarios).
```

Only the badge line and the JSON-LD value changed in the content files — no prose was touched.

> Independent of #23; the two touch different functions in `validate-repo.mjs` and merge cleanly in either order.
