### PR TITLE
docs: finish the singular-badge cleanup in CLAUDE.md and the release skill

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -36,8 +36,9 @@ CHANGELOG entry are manual; the script only fans the version out to manifests + 
    last release tag (`git log <last-tag>..HEAD --oneline`). The heading MUST be
    `## [<version>] - YYYY-MM-DD` — `npm run validate` parses that exact shape and
    fails on a bare `## <version>`.
-4. **Validate.** `npm run validate` — fails if any manifest, the README badge, or
-   the CHANGELOG entry is out of sync. Fix and re-run until clean. Then `npm test`.
+4. **Validate.** `npm run validate` — fails if any manifest, any version-bearing
+   text file, or the CHANGELOG entry is out of sync. Fix and re-run until clean.
+   Then `npm test`.
 5. **Commit & push.** Stage the changed manifests, README, and CHANGELOG; commit
    with a conventional message (`chore(release): bump version to <version>`); push
    to `main` (direct-to-main repo — no PR).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,8 +70,8 @@ To add a scenario: append to the `evals` array with the next sequential `id` and
 ## Development Commands
 
 ```bash
-npm run bump              # Propagate the package.json version to all manifests + README badge (NOT changelog)
-npm run validate          # Repo consistency: manifests, README badge, changelog, source inventory, skills structure
+npm run bump              # Propagate the package.json version to all manifests + every version-bearing text file (NOT changelog)
+npm run validate          # Repo consistency: manifests, version refs, changelog, source inventory, skills structure
 npm test                  # Unit tests for validate-repo helpers
 npm run evals             # Eval structural validation (IDs, fields, risk-code refs)
 npm run evals:live        # Live evals against the AI (requires ANTHROPIC_API_KEY)
@@ -85,4 +85,4 @@ CLAUDE_PLUGIN_ROOT=1 bash hooks/session-start   # plugin platform branch
 
 ## Release Process
 
-Set the new version in `package.json` (e.g. `npm version <v> --no-git-tag-version`), then `npm run bump` (propagates the version to all manifests + README badge) → add the new `CHANGELOG.md` section by hand → `npm run validate` → commit, push, tag GitHub release.
+Set the new version in `package.json` (e.g. `npm version <v> --no-git-tag-version`), then `npm run bump` (propagates the version to all manifests plus every version-bearing text file listed by `scripts/version-refs.mjs` — all six README badges and the docs landing-page JSON-LD) → add the new `CHANGELOG.md` section by hand → `npm run validate` → commit, push, tag GitHub release.


### PR DESCRIPTION
The follow-up you asked for on #24 — late, and rebased onto what you shipped instead of onto that branch.

Since #24 was opened you landed `version-refs.mjs` (`fdcb82a`, `468d647`), which supersedes it and generalizes further — a KIND registry covering any `docs/*.html` with JSON-LD, plus a `required` flag, neither of which my `versioned-files.mjs` had. So I closed #24 rather than rebasing it. But the documentation half of your review is still open on `main`: you updated `.claude/agents/release-manager.md` lines 5 and 27 and the release skill's step 2, and the remaining four spots still make the singular claim.

## What changed

| File | Before | After |
|---|---|---|
| `CLAUDE.md:73` | `# Propagate the package.json version to all manifests + README badge` | `… + every version-bearing text file` |
| `CLAUDE.md:74` | `# Repo consistency: manifests, README badge, changelog, …` | `… manifests, version refs, changelog, …` |
| `CLAUDE.md:91` | "propagates the version to all manifests + README badge" | names `scripts/version-refs.mjs`, all six README badges and the docs landing-page JSON-LD |
| `release/SKILL.md:39` | "fails if any manifest, the README badge, or the CHANGELOG entry" | "fails if any manifest, any version-bearing text file, or the CHANGELOG entry" |

Phrasing follows the wording you already landed in `release-manager.md:27` and the skill's step 2, so the four descriptions now read the same way.

`CLAUDE.md` is the file a maintainer is most likely to read before cutting a release, which is what made this the worst of the four to leave behind — it was still teaching the exact assumption that let the localized badges and the docs JSON-LD go stale.

## Completeness

Swept the repo for other survivors rather than fixing only the four you listed. Two remaining hits are deliberately untouched:

- `CHANGELOG.md:243` — a historical entry describing what `npm run bump` covered at that release. Rewriting it would falsify the record.
- `.github/ISSUE_TEMPLATE/bug_report.md:37` — "shown in the README badge" is addressed to a reporter looking at one README, so singular is correct there.

Everything else (`bump-version.mjs`, `validate-repo.mjs`, `consistency-qa.md`, the test) was already plural.

## Verification

```
node scripts/validate-repo.mjs   Repository validation passed for version 1.4.3.
npm test                         107 tests: 107 passed, 0 failed
npm run evals                    All structural checks passed (57 scenarios).
```

Documentation only — no executable code touched.
