### PR TITLE
fix: repair the star history chart

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -488,7 +488,7 @@ síntesis de sus ideas, aplicada a la evaluación moderna de la calidad del cód
 
 ## Historial de estrellas
 
-[![Star History Chart](https://api.star-history.com/svg?repos=hyhmrright/brooks-lint&type=Date)](https://star-history.com/#hyhmrright/brooks-lint&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=hyhmrright/brooks-lint&type=Date)](https://star-history.dera.page/#hyhmrright/brooks-lint&Date)
 
 ---
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -488,7 +488,7 @@ MIT License — 詳細は [LICENSE](LICENSE) を参照してください。
 
 ## スター履歴
 
-[![Star History Chart](https://api.star-history.com/svg?repos=hyhmrright/brooks-lint&type=Date)](https://star-history.com/#hyhmrright/brooks-lint&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=hyhmrright/brooks-lint&type=Date)](https://star-history.dera.page/#hyhmrright/brooks-lint&Date)
 
 ---
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -486,7 +486,7 @@ MIT License — 자세한 내용은 [LICENSE](LICENSE)를 참고하세요.
 
 ## Star 히스토리
 
-[![Star History Chart](https://api.star-history.com/svg?repos=hyhmrright/brooks-lint&type=Date)](https://star-history.com/#hyhmrright/brooks-lint&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=hyhmrright/brooks-lint&type=Date)](https://star-history.dera.page/#hyhmrright/brooks-lint&Date)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -488,7 +488,7 @@ their ideas, applied to modern code quality assessment.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=hyhmrright/brooks-lint&type=Date)](https://star-history.com/#hyhmrright/brooks-lint&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=hyhmrright/brooks-lint&type=Date)](https://star-history.dera.page/#hyhmrright/brooks-lint&Date)
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -474,7 +474,7 @@ MIT License——详见 [LICENSE](LICENSE)。
 
 ## Star 历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=hyhmrright/brooks-lint&type=Date)](https://star-history.com/#hyhmrright/brooks-lint&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=hyhmrright/brooks-lint&type=Date)](https://star-history.dera.page/#hyhmrright/brooks-lint&Date)
 
 ---
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -474,7 +474,7 @@ MIT License——詳見 [LICENSE](LICENSE)。
 
 ## Star 歷史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=hyhmrright/brooks-lint&type=Date)](https://star-history.com/#hyhmrright/brooks-lint&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=hyhmrright/brooks-lint&type=Date)](https://star-history.dera.page/#hyhmrright/brooks-lint&Date)
 
 ---
 


### PR DESCRIPTION
The star history chart is broken because its data source depends on the GitHub stargazer API, which no longer serves these requests. Switch it to the star-history.dera.page mirror, which uses an alternative data source that needs no API token, and apply the fix across all README translations.