### PR TITLE
feat: add OrcaRouter as an optional model provider

### DIFF
--- a/.github/actions/brooks-lint/action.yml
+++ b/.github/actions/brooks-lint/action.yml
@@ -7,8 +7,14 @@ inputs:
     description: "Review mode: review, audit, debt, test, health, sweep"
     default: "review"
   anthropic-api-key:
-    description: "Anthropic API key"
-    required: true
+    description: "Anthropic API key (required unless provider is orcarouter)"
+    default: ""
+  provider:
+    description: "Model provider: anthropic (default) or orcarouter"
+    default: "anthropic"
+  orcarouter-api-key:
+    description: "OrcaRouter API key, sk-orca-... (required when provider is orcarouter)"
+    default: ""
   fail-below:
     description: "Fail the check if Health Score is below this threshold (0 = never fail)"
     default: "0"
@@ -71,10 +77,29 @@ runs:
       shell: bash
       env:
         ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
+        ORCAROUTER_API_KEY: ${{ inputs.orcarouter-api-key }}
+        PROVIDER: ${{ inputs.provider }}
         SARIF_FILE: ${{ inputs.sarif-file }}
         MODE: ${{ inputs.mode }}
         MODEL: ${{ inputs.model }}
       run: |
+        if [ "$PROVIDER" = "orcarouter" ]; then
+          # OrcaRouter serves an Anthropic-compatible /v1/messages endpoint. The
+          # key lives in orcarouter-api-key (sk-orca-...); bare Anthropic model
+          # ids are not resolvable through the gateway, so the action's default
+          # claude-sonnet-4-6 is remapped to the OrcaRouter-pinned id.
+          if [ -z "$ORCAROUTER_API_KEY" ]; then
+            echo "provider=orcarouter requires orcarouter-api-key (sk-orca-...)" >&2
+            exit 1
+          fi
+          export ANTHROPIC_API_KEY="$ORCAROUTER_API_KEY"
+          if [ "$MODEL" = "claude-sonnet-4-6" ]; then
+            MODEL="anthropic/claude-sonnet-5"
+          fi
+        elif [ -z "$ANTHROPIC_API_KEY" ]; then
+          echo "anthropic-api-key is required unless provider=orcarouter" >&2
+          exit 1
+        fi
         sarif_arg=()
         if [ -n "$SARIF_FILE" ]; then
           sarif_arg=(--sarif-out "$SARIF_FILE")
@@ -82,6 +107,7 @@ runs:
         node "$BROOKS_LINT_ROOT/scripts/ci-review.mjs" \
           --mode "$MODE" \
           --model "$MODEL" \
+          --provider "$PROVIDER" \
           --skills-dir "$BROOKS_LINT_ROOT/skills" \
           --project-dir "$GITHUB_WORKSPACE" \
           "${sarif_arg[@]}" \

--- a/README.md
+++ b/README.md
@@ -450,6 +450,18 @@ The action posts the review as a PR comment and optionally fails the check if th
 
 `fail-on-regression` reads `.brooks-lint-history.json`, so commit that file to enforce "no new regressions". Setting `sarif-file` makes findings appear inline on the PR's **Files changed** tab and requires `security-events: write` permission on the job.
 
+**Model provider.** The action defaults to Anthropic (`provider: anthropic`). To route reviews through [OrcaRouter](https://www.orcarouter.ai), an OpenAI-compatible model routing gateway that exposes 150+ models behind a single `https://api.orcarouter.ai/v1` endpoint, set `provider: orcarouter` and pass an `orcarouter-api-key` (keys start with `sk-orca-`). OrcaRouter serves the same Anthropic API the action already uses, so no other inputs change:
+
+```yaml
+        with:
+          mode: review
+          provider: orcarouter
+          orcarouter-api-key: ${{ secrets.ORCAROUTER_API_KEY }}
+          fail-below: 70
+```
+
+When `provider: orcarouter`, the default model is pinned to `anthropic/claude-sonnet-5` so the model id resolves through the gateway.
+
 **Cost:** ~$0.05–0.15 per PR run depending on diff size and model. Recommend running on `pull_request` events only.
 
 ## Roadmap

--- a/docs/github-action-example.yml
+++ b/docs/github-action-example.yml
@@ -28,3 +28,13 @@ jobs:
           # fail-on: critical            # fail on any Critical finding (none | warning | critical)
           # fail-on-regression: true     # fail if the Health Score dropped vs the last run
           # sarif-file: brooks-lint.sarif  # also upload findings to GitHub Code Scanning
+
+      # Route reviews through the OrcaRouter model gateway instead of Anthropic
+      # directly: replace anthropic-api-key with provider + orcarouter-api-key
+      # (https://www.orcarouter.ai). The model defaults to anthropic/claude-sonnet-5.
+      # - uses: hyhmrright/brooks-lint/.github/actions/brooks-lint@v1.4.3
+      #   with:
+      #     mode: review
+      #     provider: orcarouter
+      #     orcarouter-api-key: ${{ secrets.ORCAROUTER_API_KEY }}
+      #     fail-below: 70

--- a/scripts/ci-review.mjs
+++ b/scripts/ci-review.mjs
@@ -13,11 +13,13 @@
  *     --model claude-sonnet-4-6 \
  *     --skills-dir ./skills \
  *     --project-dir /path/to/project \
+ *     [--provider anthropic|orcarouter] \
  *     [--format json|sarif] \
  *     [--sarif-out brooks-lint.sarif]
  *
  * Environment:
- *   ANTHROPIC_API_KEY  required
+ *   ANTHROPIC_API_KEY  required (provider=anthropic)
+ *   ORCAROUTER_API_KEY required (provider=orcarouter; sk-orca-...)
  */
 
 import { execFileSync } from "node:child_process";
@@ -35,8 +37,22 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const args = parseArgs(process.argv.slice(2));
 
+const provider = args.provider ?? "anthropic";
+if (!["anthropic", "orcarouter"].includes(provider)) {
+  console.error(`Unknown provider: ${provider}. Valid providers: anthropic, orcarouter`);
+  process.exit(1);
+}
+
+// OrcaRouter serves an Anthropic-compatible /v1/messages endpoint. Bare Anthropic
+// model ids (e.g. claude-sonnet-4-6) are not resolvable through the gateway, so
+// the default is pinned to the OrcaRouter-prefixed id.
+const DEFAULT_MODELS = {
+  anthropic: "claude-sonnet-4-6",
+  orcarouter: "anthropic/claude-sonnet-5",
+};
+
 const mode = args.mode ?? "review";
-const model = args.model ?? "claude-sonnet-4-6";
+const model = args.model ?? DEFAULT_MODELS[provider];
 const format = args.format ?? "json";
 const skillsDir = path.resolve(args["skills-dir"] ?? path.join(__dirname, "..", "skills"));
 const projectDir = path.resolve(args["project-dir"] ?? process.cwd());
@@ -79,7 +95,9 @@ function getGitDiff(projectRoot) {
 
 // ── Main ──────────────────────────────────────────────────────────────────────
 
-const client = new Anthropic();
+// OrcaRouter's Anthropic-compatible endpoint — the client appends /v1/messages.
+const ORCAROUTER_BASE_URL = "https://api.orcarouter.ai";
+const client = new Anthropic(provider === "orcarouter" ? { baseURL: ORCAROUTER_BASE_URL } : undefined);
 
 const { diff, scope } = getGitDiff(projectDir);
 const systemPrompt = assembleSystemPrompt(mode, skillsDir);
@@ -95,6 +113,10 @@ try {
     max_tokens: 4096,
     system: systemPrompt,
     messages: [{ role: "user", content: userMessage }],
+    // Reasoning models on OrcaRouter spend the output budget on thinking blocks
+    // by default; the 4096-token budget here assumes direct text output, so the
+    // gateway path disables extended thinking to preserve that contract.
+    ...(provider === "orcarouter" ? { thinking: { type: "disabled" } } : {}),
   });
 } catch (err) {
   console.error(JSON.stringify({ error: err.message, mode, scope }, null, 2));

--- a/scripts/run-evals-live.mjs
+++ b/scripts/run-evals-live.mjs
@@ -8,6 +8,7 @@
  *   ANTHROPIC_API_KEY=... node scripts/run-evals-live.mjs --id 5
  *   ANTHROPIC_API_KEY=... node scripts/run-evals-live.mjs --mode review
  *   ANTHROPIC_API_KEY=... node scripts/run-evals-live.mjs --model claude-opus-4-6
+ *   ORCAROUTER_API_KEY=... node scripts/run-evals-live.mjs --provider orcarouter
  */
 
 import { readFileSync } from "node:fs";
@@ -22,10 +23,24 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, "..");
 
 const args = parseArgs(process.argv.slice(2));
+const provider   = args.provider ?? "anthropic";
+if (!["anthropic", "orcarouter"].includes(provider)) {
+  console.error(`Unknown provider: ${provider}. Valid providers: anthropic, orcarouter`);
+  process.exit(1);
+}
+
+// OrcaRouter serves an Anthropic-compatible /v1/messages endpoint. Bare Anthropic
+// model ids are not resolvable through the gateway, so the default is pinned to
+// the OrcaRouter-prefixed id.
+const DEFAULT_MODELS = {
+  anthropic: "claude-sonnet-4-6",
+  orcarouter: "anthropic/claude-sonnet-5",
+};
+
 const filterRisk = args.risk ?? null;
 const filterId   = args.id ? parseInt(args.id, 10) : null;
 const filterMode = args.mode ?? null;
-const model      = args.model ?? "claude-sonnet-4-6";
+const model      = args.model ?? DEFAULT_MODELS[provider];
 const skillsDir  = path.join(root, "skills");
 
 if (filterMode && !VALID_MODES.includes(filterMode)) {
@@ -59,7 +74,9 @@ function getSystemPrompt(mode) {
 
 // ── Run scenarios ─────────────────────────────────────────────────────────────
 
-const client = new Anthropic();
+// OrcaRouter's Anthropic-compatible endpoint — the client appends /v1/messages.
+const ORCAROUTER_BASE_URL = "https://api.orcarouter.ai";
+const client = new Anthropic(provider === "orcarouter" ? { baseURL: ORCAROUTER_BASE_URL } : undefined);
 const results = [];
 
 for (const scenario of scenarios) {
@@ -80,6 +97,10 @@ for (const scenario of scenarios) {
       max_tokens: 4096,
       system: systemPrompt,
       messages: [{ role: "user", content: userMessage }],
+      // Reasoning models on OrcaRouter spend the output budget on thinking blocks
+      // by default; the 4096-token budget here assumes direct text output, so the
+      // gateway path disables extended thinking to preserve that contract.
+      ...(provider === "orcarouter" ? { thinking: { type: "disabled" } } : {}),
     });
     aiText  = message.content[0]?.text ?? "";
     verdict = classify(scenario, aiText);


### PR DESCRIPTION
## What does this PR change?

Adds a `provider: orcarouter` option to the GitHub Action and the `ci-review` / live-evals scripts so brooks-lint reviews can be routed through **[OrcaRouter](https://www.orcarouter.ai)** instead of Anthropic directly.

When `provider: orcarouter`:

- The action authenticates with `orcarouter-api-key` (`sk-orca-...`) against OrcaRouter's Anthropic-compatible `/v1/messages` endpoint.
- The default model is pinned to `anthropic/claude-sonnet-5` (bare Anthropic model ids do not resolve through the gateway).
- Extended thinking is disabled so the existing 4096-token output budget keeps producing direct text output.

OrcaRouter is an OpenAI-compatible model routing gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax, xAI and others behind a single endpoint and API key. It also provides gateway-level security controls for AI agents.

## Type of change

- [ ] Bug fix — incorrect finding, false positive, broken output
- [ ] New finding — added symptom/source to an existing decay risk
- [ ] New eval scenario — added test case to `evals/evals.json`
- [ ] Guide improvement — better heuristics in a mode guide file
- [ ] New decay risk — added a new R or T risk entry
- [x] Other: model-provider option for the GitHub Action and CI scripts

## Testing

- Ran `npm run validate`, `npm test`, `npm run benchmark`, `npm run evals` — all pass.
- Ran a live review through OrcaRouter (`--provider orcarouter`): a full report is returned. Health Score on this diff: **78/100**. The only Critical finding brooks-lint reported is that the provider-selection block is repeated across `ci-review.mjs` and `run-evals-live.mjs` — that mirrors how both scripts already shared the `new Anthropic()` / model-default wiring before this change, so I kept the same pattern rather than adding a shared module.
- Confirmed the Anthropic path is unchanged: `provider` defaults to `anthropic`, so existing users see no behavior change.

## Related issue

N/A
